### PR TITLE
change to switch, add option for windows systems

### DIFF
--- a/admin-command.php
+++ b/admin-command.php
@@ -8,9 +8,15 @@ if ( ! class_exists( 'WP_CLI' ) ) {
  * Open /wp-admin/ in a browser.
  */
 $wp_admin = function() {
-	$exec = 'xdg-open';
-	if ( 'DAR' === strtoupper( substr( PHP_OS, 0, 3 ) ) ) {
-		$exec = 'open';
+	switch ( strtoupper( substr( PHP_OS, 0, 3 ) ) ) {
+		case 'DAR':
+			$exec = 'open';
+			break;
+		case 'WIN':
+			$exec = 'start ""';
+			break;
+		default:
+			$exec = 'xdg-open';
 	}
 	passthru( $exec . ' ' . escapeshellarg( admin_url() ) );
 };


### PR DESCRIPTION
This replaces https://github.com/wp-cli/admin-command/pull/16, please excuse my opening another PR, but I just couldn't manage to merge ...

The PR is to solve https://github.com/wp-cli/admin-command/issues/15 and make this package work on Windows machines. Wasn't able to test it myself, but the single parts have been tested (ie `start "" "URL"` in a Windows cmd).

Rewrote to `switch` as to avoid `elseif` chains.