### PR TITLE
Removed psr autoloader because "src" folder doesn't exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,6 @@
         ]
     },
     "autoload": {
-        "psr-4": {
-            "": "src/"
-        },
         "files": [
             "admin-command.php"
         ]


### PR DESCRIPTION
This fixes the issue described here: https://github.com/wp-cli/wp-cli/issues/5731
