### PR TITLE
Require wp-cli/wp-cli v2.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/wp-cli/admin-command",
     "license": "MIT",
     "require": {
-        "wp-cli/wp-cli": "^2"
+        "wp-cli/wp-cli": "^2.13"
     },
     "require-dev": {
         "wp-cli/wp-cli-tests": "^5"


### PR DESCRIPTION
This way a newer version of wp-cli/wp-cli-tests will be required with better Windows compatibility.